### PR TITLE
Support webp with gmagick

### DIFF
--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -283,6 +283,14 @@ final class Image extends AbstractImage
             $image->setCompressionQuality($options['jpeg_quality']);
         }
 
+        if (isset($options['webp_quality']) && in_array($format, array('webp'))) {
+            $image->setCompressionQuality($options['webp_quality']);
+        }
+
+        if (isset($options['webp_lossless']) && in_array($format, array('webp'))) {
+            throw new NotSupportedException('Gmagick does not support webp_lossless option');
+        }
+
         if ((isset($options['png_compression_level']) || isset($options['png_compression_filter'])) && $format === 'png') {
             // first digit: compression level (default: 7)
             if (isset($options['png_compression_level'])) {
@@ -760,6 +768,7 @@ final class Image extends AbstractImage
             'jpg'  => 'image/jpeg',
             'gif'  => 'image/gif',
             'png'  => 'image/png',
+            'webp' => 'image/webp',
             'wbmp' => 'image/vnd.wap.wbmp',
             'xbm'  => 'image/xbm',
         );


### PR DESCRIPTION
Based on https://github.com/avalanche123/Imagine/pull/504 I added to support webp over Gmagick.

Could not find a option to set the lossless in Gmagick. Did oriented by the `coelasce` function and throw a NotSupportedException.